### PR TITLE
fix: wrong return value in ShaderStripperPath

### DIFF
--- a/ShaderStripperPath.cs
+++ b/ShaderStripperPath.cs
@@ -29,7 +29,7 @@ namespace Sigtrap.Editors.ShaderStripper {
             foreach (var p in _pathBlacklist){
                 if (p.Evaluate(path)) return true;
             }
-            return true;
+            return false;
         }
         #endif
     }


### PR DESCRIPTION
ShaderStripperPath.MatchShader should return false after all matches evaluated to false