### PR TITLE
Fix parsing of entries with multi-line object references

### DIFF
--- a/ShaderStripperVariantCollection.cs
+++ b/ShaderStripperVariantCollection.cs
@@ -144,7 +144,17 @@ namespace Sigtrap.Editors.ShaderStripper {
 						Shader s = AssetDatabase.LoadAssetAtPath<Shader>(AssetDatabase.GUIDToAssetPath(guid));
 
 						// Move to variants contents (skip current line, "second:" and "variants:")
-						i += 3;
+						indent = GetYamlIndent(yaml[i]);
+						i += 1;
+
+						// check if the object reference spans multiple lines
+						if ((GetYamlIndent(yaml[i]) - indent) == 2) {
+							// the object reference spans multiple lines, skip forward an extra line
+							i += 3;
+						} else {
+							i += 2;
+						}
+
 						indent = GetYamlIndent(yaml[i]);
 						var sv = new ShaderVariantCollection.ShaderVariant();
 						for (; i<yaml.Count; ++i){


### PR DESCRIPTION
At some point Unity started breaking inline objects onto multiple lines (presumedly once they reach a certain line length). This causes the parser to incorrectly begin parsing on the `variants:` line instead of the desired `- keywords:` line of the first element of the variants array.

This fixes that by detecting when the shader asset reference spans multiple lines (by looking for an increase in indentation) and skips forward an extra line if that is the case.

Example of multi-line inline object reference:
```YAML
  - first: {fileID: -6465566751694194690, guid: 750e95cd9826dc046a8b87ea0c15919e,
      type: 3}
    second:
      variants:
      - keywords: 
        passType: 8
      - keywords: _ADDITIONAL_LIGHTS
        passType: 13
      - keywords: _ADDITIONAL_LIGHTS _SCREEN_SPACE_OCCLUSION
        passType: 13
      - keywords: _ADDITIONAL_LIGHTS _SCREEN_SPACE_OCCLUSION _SHADOWS_SOFT
        passType: 13
```