### PR TITLE
Account for empty variant arrays in parser

### DIFF
--- a/ShaderStripperVariantCollection.cs
+++ b/ShaderStripperVariantCollection.cs
@@ -145,6 +145,19 @@ namespace Sigtrap.Editors.ShaderStripper {
 
 						// Move to variants contents (skip current line, "second:" and "variants:")
 						i += 3;
+
+						// it's possible for the variants array to be empty (represented by `variants: []`)
+						if (i >= yaml.Count) {
+							// this was the final entry, we've reached EOF
+							break;
+						}
+
+						if (GetYamlIndent(yaml[i]) == indent) {
+							// the variants array was empty and we're now on the `- first:` line of the next entry
+							i -= 1; // decrement here because the loop will increment
+							continue;
+						}
+
 						indent = GetYamlIndent(yaml[i]);
 						var sv = new ShaderVariantCollection.ShaderVariant();
 						for (; i<yaml.Count; ++i){


### PR DESCRIPTION
It's possible for entries in `.shadervariants` assets to have an empty variants array. Eg. `variants: []`.

This causes the parser to go out-of-bounds in the `yaml` list when the final entry has an empty variants array. When not the final entry, it probably causes the next entry to be parsed incorrectly.

Example of empty variant array:
```YAML
  - first: {fileID: 4800000, guid: a5e0f9ecc5bd641c0b9a6c17fa79ded3, type: 3}
    second:
      variants: []
```